### PR TITLE
Introduce Caelus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "kamal", require: false
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
 
+# Caelus specific
+gem "astronoby", github: "rhannequin/astronoby"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/rhannequin/astronoby.git
+  revision: f09e12a7ccf61daf02ce4afa2370d0d5650a5bc2
+  specs:
+    astronoby (0.7.0)
+      ephem (~> 0.3)
+      matrix (~> 0.4.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -105,6 +113,10 @@ GEM
     dotenv (3.1.8)
     drb (2.2.3)
     ed25519 (1.4.0)
+    ephem (0.4.0)
+      minitar (~> 0.12)
+      numo-narray (~> 0.9.2.1)
+      zlib (~> 3.2)
     erb (5.0.2)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -156,6 +168,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.3)
     mini_mime (1.1.5)
+    minitar (0.12.1)
     minitest (5.25.5)
     msgpack (1.8.0)
     net-imap (0.5.9)
@@ -187,6 +200,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
+    numo-narray (0.9.2.1)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -391,6 +405,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.3)
+    zlib (3.2.1)
 
 PLATFORMS
   aarch64-linux
@@ -404,6 +419,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  astronoby!
   bootsnap
   brakeman
   capybara

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/app/controllers/caelus/application_controller.rb
+++ b/app/controllers/caelus/application_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Caelus
+  class ApplicationController < ActionController::Base
+    layout "caelus"
+  end
+end

--- a/app/controllers/caelus/home_controller.rb
+++ b/app/controllers/caelus/home_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Caelus
+  class HomeController < ApplicationController
+    def index
+      ephem = SPK.inpop19a
+      time = Time.now
+      instant = Astronoby::Instant.from_time(time)
+      @sun = Astronoby::Sun.new(instant: instant, ephem: ephem)
+      @mercury = Astronoby::Mercury.new(instant: instant, ephem: ephem)
+      @venus = Astronoby::Venus.new(instant: instant, ephem: ephem)
+      @earth = Astronoby::Earth.new(instant: instant, ephem: ephem)
+      @mars = Astronoby::Mars.new(instant: instant, ephem: ephem)
+      @jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
+      @saturn = Astronoby::Saturn.new(instant: instant, ephem: ephem)
+      @uranus = Astronoby::Uranus.new(instant: instant, ephem: ephem)
+      @neptune = Astronoby::Neptune.new(instant: instant, ephem: ephem)
+    end
+  end
+end

--- a/app/helpers/caelus/number_helper.rb
+++ b/app/helpers/caelus/number_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Caelus
+  module NumberHelper
+    def format_number(number, precision: 2, unit: nil)
+      formatted_number = format("%.#{precision}f", number)
+      formatted_number += " #{unit}" if unit
+      formatted_number
+    end
+  end
+end

--- a/app/javascript/controllers/caelus/dark_mode_controller.js
+++ b/app/javascript/controllers/caelus/dark_mode_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["darkIcon", "lightIcon"]
+
+  connect() {
+    this.updateIconVisibility()
+  }
+
+  toggleTheme() {
+    document.documentElement.classList.toggle("dark")
+    this.updateIconVisibility()
+  }
+
+  updateIconVisibility() {
+    const isDark = document.documentElement.classList.contains("dark")
+    this.darkIconTarget.classList.toggle("hidden", isDark)
+    this.lightIconTarget.classList.toggle("hidden", !isDark)
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/views/caelus/home/index.html.erb
+++ b/app/views/caelus/home/index.html.erb
@@ -1,0 +1,77 @@
+<div class="px-6 py-6 space-y-6">
+  <h1
+    class="text-3xl text-indigo-700 dark:text-indigo-300
+      font-boldtracking-tight"
+  >
+    <%= t ".title" %>
+  </h1>
+
+  <h2 class="text-xl font-semibold text-indigo-600 dark:text-indigo-400">
+    <%= t ".subtitle" %>
+  </h2>
+
+  <table class="table-auto w-full text-left">
+    <thead>
+      <tr>
+        <th>&nbsp;</th>
+        <th>
+          <%= t ".distances_table.distance_from_sun" %>
+          <br>
+          (<%= t "caelus.units.astronomical_unit.symbol" %>)
+        </th>
+        <th>
+          <%= t ".distances_table.distance_from_earth" %>
+          <br>
+          (<%= t "caelus.units.astronomical_unit.symbol" %>)
+        </th>
+        <th>
+          <%= t ".distances_table.velocity" %>
+          <br>
+          (<%= t "caelus.units.km_per_second.symbol" %>)
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+    <% [
+         @sun,
+         @mercury,
+         @venus,
+         @earth,
+         @mars,
+         @jupiter,
+         @saturn,
+         @uranus,
+         @neptune
+       ].each do |body| %>
+        <tr>
+          <td>
+            <strong>
+              <%= body.class.name.delete_prefix("Astronoby::") %>
+            </strong>
+          </td>
+          <td>
+            <%=
+              format_number(
+                (body.astrometric.position - @sun.astrometric.position)
+                  .magnitude
+                  .au
+                  .round(2)
+              )
+            %>
+          </td>
+          <td><%=format_number body.astrometric.distance.au.round(2) %></td>
+          <td>
+            <%=
+              format_number(
+                (body.astrometric.velocity - @sun.astrometric.velocity)
+                  .magnitude
+                  .kmps
+                  .round(2)
+              )
+            %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/caelus/shared/_dark_mode_toggle.html.erb
+++ b/app/views/caelus/shared/_dark_mode_toggle.html.erb
@@ -1,0 +1,46 @@
+<div class="flex justify-end m-0">
+  <button
+    id="app-darkmode-toggle"
+    type="button"
+    class="cursor-pointer text-gray-800 dark:text-gray-100 hover:text-gray-600
+      dark:hover:text-gray-300 transition-colors"
+    data-caelus--dark-mode-target="themeToggle"
+    data-action="click->caelus--dark-mode#toggleTheme"
+    aria-label="Toggle dark mode"
+  >
+    <svg
+      class="w-6 h-6 hidden"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+      data-caelus--dark-mode-target="darkIcon"
+    >
+      <path
+        d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
+        fill="currentColor"
+      ></path>
+    </svg>
+
+    <svg
+      class="w-6 h-6 hidden"
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+      data-caelus--dark-mode-target="lightIcon"
+    >
+      <path
+        d="
+          M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0
+          018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0
+          00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0
+          11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0
+          100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1
+          1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414
+          8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4
+          11a1 1 0 100-2H3a1 1 0 000 2h1z
+        "
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        fill="currentColor"
+      ></path>
+    </svg>
+  </button>
+</div>

--- a/app/views/layouts/caelus.html.erb
+++ b/app/views/layouts/caelus.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>
+    <%= content_for(:title) || "Caelus" %>
+  </title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= yield :head %>
+  <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+  <%= javascript_importmap_tags %>
+</head>
+<body
+  class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100"
+  data-controller="caelus--dark-mode"
+>
+  <main class="px-6 py-8 space-y-6">
+    <%= render "caelus/shared/dark_mode_toggle" %>
+    <%= yield %>
+  </main>
+</body>
+</html>

--- a/config/initializers/astronoby.rb
+++ b/config/initializers/astronoby.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+Astronoby.configuration.cache_enabled = true
+
+class SPK
+  include Singleton
+
+  def self.inpop19a
+    instance.inpop19a
+  end
+
+  def inpop19a
+    Astronoby::Ephem.load("lib/astronoby/spk/inpop19a.bsp")
+  end
+end

--- a/config/locales/caelus/en.yml
+++ b/config/locales/caelus/en.yml
@@ -1,0 +1,17 @@
+en:
+  caelus:
+    home:
+      index:
+        distances_table:
+          distance_from_earth: Distance from Earth
+          distance_from_sun: Distance from Sun
+          velocity: Velocity
+        subtitle: Accurate and open-source astronomical ephemeris
+        title: Caelus
+    units:
+      astronomical_unit:
+        name: Astronomical Unit
+        symbol: AU
+      km_per_second:
+        name: Kilometers per second
+        symbol: km/s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,8 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", :as => :rails_health_check
 
   root "about#index"
+
+  namespace :caelus do
+    root "home#index"
+  end
 end

--- a/spec/helpers/caelus/number_helper_spec.rb
+++ b/spec/helpers/caelus/number_helper_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Caelus::NumberHelper do
+  include Caelus::NumberHelper
+
+  describe "#format_number" do
+    it "formats a number with default precision and no unit" do
+      expect(format_number(123.456)).to eq("123.46")
+    end
+
+    it "formats a number with specified precision" do
+      expect(format_number(123.456, precision: 3)).to eq("123.456")
+    end
+
+    it "formats a number with trailing zeros removed" do
+      expect(format_number(123.4500)).to eq("123.45")
+    end
+
+    it "formats a number with a unit" do
+      expect(format_number(123.456, unit: "kg")).to eq("123.46 kg")
+    end
+
+    it "handles zero correctly" do
+      expect(format_number(0)).to eq("0.00")
+      expect(format_number(0, precision: 3)).to eq("0.000")
+      expect(format_number(0, unit: "m")).to eq("0.00 m")
+    end
+  end
+end

--- a/spec/requests/caelus/home_spec.rb
+++ b/spec/requests/caelus/home_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Caelus Home", type: :request do
+  describe "GET /caelus" do
+    it "returns a successful response" do
+      get caelus_root_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/support/astronoby.rb
+++ b/spec/support/astronoby.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Astronoby.reset_configuration!
+    Astronoby.configuration.cache_enabled = false
+  end
+end


### PR DESCRIPTION
This introduces Caelus, an accurate and open-source astronomical ephemeris.

This project is meant to use Astronoby and other tools to provide accurate astronomical data while keeping the code open-source and document the celestial events.

It was inspired by the great [Heavens Above](https://www.heavens-above.com) with the idea to be as transparent as possible about the displayed information:
* What it is semantically
* What it means scientifically
* How it was computed

---

On the technical side, this first change introduces several parts as basis for what will come next:
* `Caelus` module to keep it separate from other sub-projects in the repository
* Use of [Astronoby](https://github.com/rhannequin/astronoby)
* Use of a singleton to load the INPOP19a ephemeris once and have it available anywhere
* Display the distance from the Sun, distance from Earth and velocity of each major Solar System body
* Use i18n
* TailwindCSS for styling
* Have a light/dark mode toggle using Stimulus
* Helper for displaying numerical values
* Code coverage