### PR TITLE
[caelus] Use dedicated classes for planets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rhannequin/astronoby.git
-  revision: f09e12a7ccf61daf02ce4afa2370d0d5650a5bc2
+  revision: 075feb469fa212dffbc1e84b36b81bb8b108ce35
   specs:
     astronoby (0.7.0)
       ephem (~> 0.3)
@@ -118,7 +118,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
-    ephem (0.4.0)
+    ephem (0.4.1)
       minitar (~> 0.12)
       numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)

--- a/app/controllers/caelus/home_controller.rb
+++ b/app/controllers/caelus/home_controller.rb
@@ -3,18 +3,15 @@
 module Caelus
   class HomeController < ApplicationController
     def index
-      ephem = SPK.inpop19a
-      time = Time.now
-      instant = Astronoby::Instant.from_time(time)
-      @sun = Astronoby::Sun.new(instant: instant, ephem: ephem)
-      @mercury = Astronoby::Mercury.new(instant: instant, ephem: ephem)
-      @venus = Astronoby::Venus.new(instant: instant, ephem: ephem)
-      @earth = Astronoby::Earth.new(instant: instant, ephem: ephem)
-      @mars = Astronoby::Mars.new(instant: instant, ephem: ephem)
-      @jupiter = Astronoby::Jupiter.new(instant: instant, ephem: ephem)
-      @saturn = Astronoby::Saturn.new(instant: instant, ephem: ephem)
-      @uranus = Astronoby::Uranus.new(instant: instant, ephem: ephem)
-      @neptune = Astronoby::Neptune.new(instant: instant, ephem: ephem)
+      @planets = [
+        Mercury.new,
+        Venus.new,
+        Mars.new,
+        Jupiter.new,
+        Saturn.new,
+        Uranus.new,
+        Neptune.new
+      ]
     end
   end
 end

--- a/app/controllers/caelus/planets_controller.rb
+++ b/app/controllers/caelus/planets_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Caelus
+  class PlanetsController < ApplicationController
+    SUPPORTED_PLANETS = {
+      mercury: Mercury,
+      venus: Venus,
+      mars: Mars,
+      jupiter: Jupiter,
+      saturn: Saturn,
+      uranus: Uranus,
+      neptune: Neptune
+    }.freeze
+    def show
+      @planet = planet_class.new
+    end
+
+    private
+
+    def planet_class
+      SUPPORTED_PLANETS.fetch(params[:id].to_sym) do
+        raise ActionController::RoutingError, "Planet not found"
+      end
+    end
+  end
+end

--- a/app/models/caelus/earth.rb
+++ b/app/models/caelus/earth.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Earth
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Earth
+    end
+
+    def self.key
+      :earth
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+
+    def distance_from_earth
+      Astronoby::Distance.zero
+    end
+  end
+end

--- a/app/models/caelus/jupiter.rb
+++ b/app/models/caelus/jupiter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Jupiter
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Jupiter
+    end
+
+    def self.key
+      :jupiter
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/caelus/mars.rb
+++ b/app/models/caelus/mars.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Mars
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Mars
+    end
+
+    def self.key
+      :mars
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/caelus/mercury.rb
+++ b/app/models/caelus/mercury.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Mercury
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Mercury
+    end
+
+    def self.key
+      :mercury
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/caelus/neptune.rb
+++ b/app/models/caelus/neptune.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Neptune
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Neptune
+    end
+
+    def self.key
+      :neptune
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/caelus/saturn.rb
+++ b/app/models/caelus/saturn.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Saturn
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Saturn
+    end
+
+    def self.key
+      :saturn
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/caelus/uranus.rb
+++ b/app/models/caelus/uranus.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Uranus
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Uranus
+    end
+
+    def self.key
+      :uranus
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/caelus/venus.rb
+++ b/app/models/caelus/venus.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Caelus
+  class Venus
+    include Planetable
+
+    def self.planet_class
+      Astronoby::Venus
+    end
+
+    def self.key
+      :venus
+    end
+
+    def initialize(time: Time.now)
+      @time = time
+    end
+  end
+end

--- a/app/models/concerns/caelus/planetable.rb
+++ b/app/models/concerns/caelus/planetable.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Caelus
+  module Planetable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def planet_class
+        raise NotImplementedError,
+          "You must implement the .planet_class class method in #{name}"
+      end
+
+      def key
+        raise NotImplementedError,
+          "You must implement the .key class method in #{name}"
+      end
+
+      def planet_name
+        I18n.t("caelus.models.planets.#{key}.name")
+      end
+    end
+
+    included do
+      delegate :constellation, to: :planet
+
+      def distance_from_earth
+        @distance_from_earth ||= planet.astrometric.distance
+      end
+
+      private
+
+      def planet
+        @planet ||= self.class.planet_class.new(
+          ephem: SPK.inpop19a,
+          instant: Astronoby::Instant.from_time(@time)
+        )
+      end
+    end
+  end
+end

--- a/app/views/caelus/home/index.html.erb
+++ b/app/views/caelus/home/index.html.erb
@@ -15,61 +15,19 @@
       <tr>
         <th>&nbsp;</th>
         <th>
-          <%= t ".distances_table.distance_from_sun" %>
-          <br>
-          (<%= t "caelus.units.astronomical_unit.symbol" %>)
-        </th>
-        <th>
-          <%= t ".distances_table.distance_from_earth" %>
-          <br>
-          (<%= t "caelus.units.astronomical_unit.symbol" %>)
-        </th>
-        <th>
-          <%= t ".distances_table.velocity" %>
-          <br>
-          (<%= t "caelus.units.km_per_second.symbol" %>)
+          <%= t ".distances_table.distance_from_earth" %> (<%= t "caelus.units.astronomical_unit.symbol" %>)
         </th>
       </tr>
     </thead>
     <tbody>
-    <% [
-         @sun,
-         @mercury,
-         @venus,
-         @earth,
-         @mars,
-         @jupiter,
-         @saturn,
-         @uranus,
-         @neptune
-       ].each do |body| %>
+    <% @planets.each do |planet| %>
         <tr>
           <td>
             <strong>
-              <%= body.class.name.delete_prefix("Astronoby::") %>
+              <%= planet.class.planet_name %>
             </strong>
           </td>
-          <td>
-            <%=
-              format_number(
-                (body.astrometric.position - @sun.astrometric.position)
-                  .magnitude
-                  .au
-                  .round(2)
-              )
-            %>
-          </td>
-          <td><%=format_number body.astrometric.distance.au.round(2) %></td>
-          <td>
-            <%=
-              format_number(
-                (body.astrometric.velocity - @sun.astrometric.velocity)
-                  .magnitude
-                  .kmps
-                  .round(2)
-              )
-            %>
-          </td>
+          <td><%= format_number planet.distance_from_earth.au.round(2) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/caelus/planets/show.html.erb
+++ b/app/views/caelus/planets/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @planet.class.planet_name %></h1>

--- a/config/locales/caelus/en.yml
+++ b/config/locales/caelus/en.yml
@@ -4,10 +4,26 @@ en:
       index:
         distances_table:
           distance_from_earth: Distance from Earth
-          distance_from_sun: Distance from Sun
-          velocity: Velocity
         subtitle: Accurate and open-source astronomical ephemeris
         title: Caelus
+    models:
+      planets:
+        mercury:
+          name: Mercury
+        venus:
+          name: Venus
+        earth:
+          name: Earth
+        mars:
+          name: Mars
+        jupiter:
+          name: Jupiter
+        saturn:
+          name: Saturn
+        uranus:
+          name: Uranus
+        neptune:
+          name: Neptune
     units:
       astronomical_unit:
         name: Astronomical Unit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
 
   namespace :caelus do
     root "home#index"
+
+    resources :planets, only: [:show], param: :id
   end
 end

--- a/spec/requests/caelus/planets_spec.rb
+++ b/spec/requests/caelus/planets_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Caelus Planets", type: :request do
+  describe "GET /caelus/planets/:id" do
+    context "when the planet exists" do
+      it "returns a successful response" do
+        get caelus_planet_path(id: "jupiter")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Jupiter")
+      end
+    end
+
+    context "when the planet does not exist" do
+      it "returns a 404 status" do
+        get caelus_planet_path(id: "pluto")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces a `Planetable` concern to have dedicated classes for planets without having to rely directly on Astronoby and avoiding code redundancy.