### PR TITLE
[caelus] Fix cookie consent withdraw

### DIFF
--- a/app/views/caelus/privacy_policy/show.html.erb
+++ b/app/views/caelus/privacy_policy/show.html.erb
@@ -100,9 +100,9 @@
           <%= link_to(
             t("caelus.privacy_policy.sections.your_rights.rights.delete_my_data"),
             caelus_cookie_consent_path,
-            method: :patch,
+            method: :delete,
             data: {
-              turbo_method: :patch,
+              turbo_method: :delete,
             },
             class: "link"
           ) %>.
@@ -113,9 +113,9 @@
           <%= link_to(
             t("caelus.privacy_policy.sections.your_rights.rights.clearing_cookies"),
             caelus_cookie_consent_path,
-            method: :patch,
+            method: :delete,
             data: {
-              turbo_method: :patch,
+              turbo_method: :delete,
             },
             class: "link"
           ) %>


### PR DESCRIPTION
Withdrawing cookie consent wasn't working because we weren't using the right route.